### PR TITLE
Utilize NVIDIA discrete GPUs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,11 +30,27 @@
         "--net=host",
         "--pid=host",
         "--ipc=host",
-        "-e", "DISPLAY=${env:DISPLAY}"
+        "--gpus=all",
+        "--runtime=nvidia",
+        "--device=/dev/dxg",
+        "--privileged",
+        "-e", "NVIDIA_VISIBLE_DEVICES=all",
+        "-e", "NVIDIA_DRIVER_CAPABILITES=all",
+        "-e", "DISPLAY=${env:DISPLAY}",
+        "-e", "WAYLAND_DISPLAY=${env:WAYLAND_DISPLAY}",
+        "-e", "LD_LIBRARY_PATH=/usr/lib/wsl/lib",
+        "-e", "MESA_D3D12_DEFAULT_ADAPTER_NAME=NVIDIA",
+        "-e", "MESA_LOADER_DRIVER_OVERRIDE=d3d12",
+        "-e", "GALLIUM_DRIVER=d3d12",
+        "-e", "LIBGL_ALWAYS_INDIRECT=0"
+
     ],
     "mounts": [
+       "source=/dev/dri,target=/dev/dri,type=bind,consistency=cached",
        "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached",
-       "source=/dev/dri,target=/dev/dri,type=bind,consistency=cached"
+       "source=/usr/lib/wsl,target=/usr/lib/wsl,type=bind,consistency=cached",
+       "source=/usr/lib/x86_64-linux-gnu/dri,target=/usr/lib/x86_64-linux-gnu/dri,type=bind,consistency=cached",
+       "source=//usr/share/glvnd,target=/usr/share/glvnd,type=bind,consistency=cached"
     ],
     "postCreateCommand": ". .devcontainer/setup.sh && sudo rosdep update --rosdistro=jazzy && sudo rosdep install --from-paths lib src --ignore-src -y --rosdistro=jazzy && sudo chown -R $(whoami) /home/ros2_ws/ && (rm -r build/ || true) && colcon build --symlink-install"
 }


### PR DESCRIPTION
Closes #18 
Gazebo runs at 40FPS on my desktop with the current URDF model
Some environment variables/mounts may be redundant. If you would like to test that, be my guest
Process is still not on `nvidia-sml`, which is confusing